### PR TITLE
Update repo URL

### DIFF
--- a/QuoteOfTheLobby/QuoteOfTheLobby.json
+++ b/QuoteOfTheLobby/QuoteOfTheLobby.json
@@ -5,7 +5,7 @@
   "Description": "Displays a random dialogue, and/or the datacenter you'll be connecting to when you press GAME START.",
   "InternalName": "quoteOfTheLobby",
   "ApplicableVersion": "any",
-  "RepoUrl": "https://github.com/Soreepeong/QuoteOfTheLobby.json",
+  "RepoUrl": "https://github.com/Soreepeong/QuoteOfTheLobby",
   "Tags": [
     "qotd",
     "lobby",


### PR DESCRIPTION
The repo URL points to an invalid repo due to the .json, just a quick pull to correct that so the "Visit Plugin URL" button works in Dalamud.